### PR TITLE
start tag layout

### DIFF
--- a/_layouts/story.html
+++ b/_layouts/story.html
@@ -42,10 +42,8 @@ layout: default
         <svg class="icon icon-tag">
           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-tag"></use>
         </svg>
-        <!-- Uncomment if you want a custom tagging setup. This is optional and only useful if you're not hosting on github, which doesn't support custom jekyll plugins -->
-        <!--
          <a href="{{ root_url }}/tag/{{tags}}.html">{{ tags }}</a>
-         -->
+
         {{ tags }}
       </li>
       {% endfor %}

--- a/_layouts/tag_page.html
+++ b/_layouts/tag_page.html
@@ -1,9 +1,71 @@
 ---
 layout: default
 ---
-<h2>{{ page.tag }}</h2>
-<ul>
-{% for post in page.posts %}
-  <li><a href="{{ post.url }}">{{ post.title }}</a> ({{ post.date | date_to_string }} | Tags: {{ post | tags }})</li>
+
+{% assign rawtags = "" %}
+{% for post in site.posts %}
+{% assign ttags = post.tags | join:'|' | append:'|' %}
+{% assign rawtags = rawtags | append:ttags %}
 {% endfor %}
-</ul>
+{% assign rawtags = rawtags | split:'|' | sort %}
+
+{% assign site.tags = "" %}
+{% for tag in rawtags %}
+{% if tag != "" %}
+{% if tags == "" %}
+{% assign tags = tag | split:'|' %}
+{% endif %}
+{% unless tags contains tag %}
+{% assign tags = tags | join:'|' | append:'|' | append:tag | split:'|' %}
+{% endunless %}
+{% endif %}
+{% endfor %}
+
+
+<h2>{{ page.tag }}</h2>
+
+<div class="trigger">
+  <ul>
+
+    {% comment %} We only want to output Story pages, not any other pages (such as the 404 error page or index page){% endcomment %}
+
+    {% assign pages = site.pages %}
+    {% assign stories = pages | where: "layout", "story"%}
+
+    {% assign sorted = stories | sort: "historical-date.year" | reverse %}
+
+
+    {% for story in sorted %}
+    {% assign is_wip = page.story-status.wip %}
+
+    {% if story.historical-date.bce %}
+    {% if story.tags contains page.tag %}
+    <li><a class="page-link" href="{{ story.url | prepend : site.baseurl }}">
+
+        {{story.historical-date.year}}
+        BCE:
+        {{ story.title }}
+        {% if is_wip %} (WIP) {% endif %}
+      </a></li>
+    {%endif%}
+    {% endif %}
+    {% endfor %}
+
+    {% comment %} we sort by year, but don't forget we sorted alll BCE dates... backwards! {% endcomment %}
+    {% assign sorted_forwards = sorted | reverse %}
+
+    {% for story in sorted_forwards %}
+    {% unless story.historical-date.bce %}
+    {% if story.tags contains page.tag %}
+    <li><a class="page-link" href="{{ story.url | prepend : site.baseurl }}">
+        {{story.historical-date.year}}
+        CE:
+        {{ story.title }}
+        {% if is_wip %} (WIP) {% endif %}
+      </a></li>
+    {%endif%}
+    {% endunless %}
+    {% endfor %}
+
+  </ul>
+</div>

--- a/tag/How We Do Things.md
+++ b/tag/How We Do Things.md
@@ -1,0 +1,4 @@
+---
+layout: tag_page
+tag: "How We Do Things"
+---

--- a/tag/HowWeDoThings.md
+++ b/tag/HowWeDoThings.md
@@ -1,0 +1,4 @@
+---
+layout: tag_page
+tag: "HowWeDoThings"
+---

--- a/tag/index.md
+++ b/tag/index.md
@@ -1,5 +1,11 @@
+---
+layout: default
+title: Tag index
+show-in-nav: true
+---
+
 {% assign rawtags = "" %}
-{% for post in site.posts %}
+{% for post in site.pages %}
   {% assign ttags = post.tags | join:'|' | append:'|' %}
   {% assign rawtags = rawtags | append:ttags %}
 {% endfor %}
@@ -15,4 +21,12 @@
       {% assign tags = tags | join:'|' | append:'|' | append:tag | split:'|' %}
     {% endunless %}
   {% endif %}
+{% endfor %}
+
+{% for tag in tags %}
+<li><a class="page-link" href="{{ tag | prepend : site.baseurl }}">
+
+    {{tag}}
+
+  </a></li>
 {% endfor %}


### PR DESCRIPTION
### Related issue
<!-- Please type the GitHub issue related to this pull request, if there is one. If not, type "N/A". -->
#98 

### Proposed change
Adds ability to collate by tag. Preview of tag page: 

<img width="547" alt="lost of tags including some duplicates" src="https://user-images.githubusercontent.com/9271438/147956880-56b31e72-0b37-4567-9b91-f3535db2a66b.png">

preview of page for a singletag: 

<img width="869" alt="image" src="https://user-images.githubusercontent.com/9271438/147956962-e9ac5232-a6c1-435e-a349-5dd6200b2382.png">


note: I've made pages for two of the tags, you'll need to do the rest (see the tags folder!)

and to remove weird looking tags from the main tag page... remove them from your page yaml.


### Reviewers
<!-- Please remember to select any reviewers whose skills might be of help! Otherwise, this will only appear in [Ismael-KG's](https://github.com/Ismael-KG)'s notifications. -->
- [ ] Reviewers selected
